### PR TITLE
Reorganize results directory by sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ auto-app2/
 │   ├── raw_data/            # 生データ（FASTQ等）
 │   ├── reference/           # 参照ゲノム
 │   ├── results/             # 解析結果
+│   │   └── <ProjectID>/
+│   │       └── <AccessionID>/
+│   │           ├── bam_files/
+│   │           ├── softclipped/
+│   │           ├── dedup/
+│   │           ├── mapdamage/
+│   │           ├── qualimap/
+│   │           └── vcf_files/
 │   ├── logs/                # ログ
 │   └── temp/                # 一時ファイル
 ├── requirements.txt         # Python依存パッケージ
@@ -143,8 +151,8 @@ python3 main.py
    - `modules/analyzers.py`  
    - GATK, mapDamage, Qualimap等を呼び出し
 
-6. **結果の保存・レポート生成**  
-   - `data/results/` 以下に各種出力ファイルを保存
+6. **結果の保存・レポート生成**
+   - `data/results/<プロジェクトID>/<Accession ID>/` 以下に各種出力ファイルを保存
 
 ---
 
@@ -164,8 +172,8 @@ python3 main.py
   - ダウンロードしたFASTQ等の生データ
 - `data/reference/`  
   - 参照ゲノム（FASTA, FAI等）
-- `data/results/`  
-  - 解析結果（BAM, VCF, QCレポート等）
+- `data/results/<プロジェクトID>/<Accession ID>/`
+  - サンプルごとの解析結果（BAM, VCF, QCレポート等）
 - `data/logs/`  
   - 実行ログ
 - `data/temp/`  

--- a/config.py
+++ b/config.py
@@ -15,21 +15,11 @@ class PipelineConfig:
         self.logs_dir = self.base_dir / "logs"
         self.temp_dir = self.base_dir / "temp"
         
-        # サブディレクトリ
-        self.bam_dir = self.results_dir / "bam_files"
-        self.softclipped_dir = self.results_dir / "softclipped"
-        self.dedup_dir = self.results_dir / "dedup"
-        self.mapdamage_dir = self.results_dir / "mapdamage"
-        self.qualimap_dir = self.results_dir / "qualimap"
-        self.vcf_dir = self.results_dir / "vcf_files"
-        
         # 参照ゲノム
         self.reference_genome = args.reference_genome or (self.base_dir / "reference" / "equCab3.nochrUn.fa")
-        
+
         # 作成
-        for dir_path in [self.raw_data_dir, self.results_dir, self.logs_dir, self.temp_dir,
-                        self.bam_dir, self.softclipped_dir, self.dedup_dir, 
-                        self.mapdamage_dir, self.qualimap_dir, self.vcf_dir]:
+        for dir_path in [self.raw_data_dir, self.results_dir, self.logs_dir, self.temp_dir]:
             dir_path.mkdir(parents=True, exist_ok=True)
 
 def parse_args():

--- a/modules/analyzers.py
+++ b/modules/analyzers.py
@@ -12,8 +12,8 @@ class MapDamageAnalyzer:
         """Run mapDamage analysis"""
         logger.info(f"Running mapDamage for {sample_acc}")
         
-        sample_outdir = self.config.mapdamage_dir / sample_acc
-        sample_outdir.mkdir(exist_ok=True)
+        sample_outdir = self.config.results_dir / sample_acc / "mapdamage"
+        sample_outdir.mkdir(parents=True, exist_ok=True)
         
         # Filter BAM (mapQ>=30, POS>=300)
         filtered_bam = self.config.temp_dir / f"{sample_acc}_filtered.bam"
@@ -47,8 +47,8 @@ class QualimapAnalyzer:
         """Run Qualimap quality check"""
         logger.info(f"Running Qualimap for {sample_acc}")
         
-        sample_outdir = self.config.qualimap_dir / sample_acc
-        sample_outdir.mkdir(exist_ok=True)
+        sample_outdir = self.config.results_dir / sample_acc / "qualimap"
+        sample_outdir.mkdir(parents=True, exist_ok=True)
         
         qualimap_cmd = [
             "qualimap", "bamqc", "-bam", str(dedup_bam),
@@ -72,7 +72,9 @@ class HaplotypeCaller:
         """Run GATK HaplotypeCaller"""
         logger.info(f"Running HaplotypeCaller for {sample_acc}")
         
-        vcf_file = self.config.vcf_dir / f"{sample_acc}.vcf"
+        vcf_dir = self.config.results_dir / sample_acc / "vcf_files"
+        vcf_dir.mkdir(parents=True, exist_ok=True)
+        vcf_file = vcf_dir / f"{sample_acc}.vcf"
         
         haplotypecaller_cmd = [
             "gatk", "HaplotypeCaller",
@@ -90,4 +92,4 @@ class HaplotypeCaller:
             return vcf_file
         except subprocess.CalledProcessError as e:
             logger.error(f"HaplotypeCaller failed for {sample_acc}: {e}")
-            return None 
+            return None

--- a/modules/softclipper.py
+++ b/modules/softclipper.py
@@ -68,7 +68,9 @@ class SoftClipper:
         logger.info(f"Running softclipping for {sample_acc}")
         
         input_bam = bam_file
-        output_bam = self.config.softclipped_dir / f"{sample_acc}_softclipped.bam"
+        sample_dir = self.config.results_dir / sample_acc / "softclipped"
+        sample_dir.mkdir(parents=True, exist_ok=True)
+        output_bam = sample_dir / f"{sample_acc}_softclipped.bam"
         
         try:
             with pysam.AlignmentFile(input_bam, "rb") as in_bam, \


### PR DESCRIPTION
## Summary
- create sample-specific result directories
- update modules to write outputs within each accession's folder
- adjust README to document new layout

## Testing
- `python -m py_compile config.py modules/*.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68870700a0108324ba8a97d879eec3d5